### PR TITLE
fix: specify OCI version compatible

### DIFF
--- a/docker_php_oci_ARM64/Dockerfile
+++ b/docker_php_oci_ARM64/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:rolling
 
-LABEL maintainer="hoplin"
-LABEL email="jhoplin7259@gmail.com"
+LABEL maintainer="hoplin,bochankang"
+LABEL email="jhoplin7259@gmail.com,gillco00@naver.com"
 
 # Non Interactive set
 ARG DEBIAN_FRONTEND=noninteractive
@@ -35,7 +35,7 @@ RUN mkdir -p /usr/lib/oracle/client\
 && echo "ORACLE_HOME=/usr/lib/oracle/client/lib" >> /etc/profile\
 && ldconfig\
 && pecl channel-update pecl.php.net\
-&& echo 'instantclient,/usr/lib/oracle/client/lib/' | pecl install oci8\
+&& echo 'instantclient,/usr/lib/oracle/client/lib/' | pecl install oci8-3.2.0\
 && echo "extension=oci8.so" >> /etc/php/8.1/cli/php.ini\
 && cd /etc/php/8.1/mods-available && echo "extension=oci8.so" >> oci.ini\
 && cd /etc/php/8.1/apache2/conf.d && ln -s /etc/php/8.1/mods-available/oci.ini 20-oci.ini
@@ -48,7 +48,7 @@ RUN mkdir -p /usr/lib/oracle/client\
 # ln[34] : Enroll oracle home env variable
 # ln[35] : Update dynamic linker
 # ln[36] : Update PECL(PHP Extension Community Library)
-# ln[37] : Install oci8
+# ln[37] : Install oci8-3.2.0 (SEE clearly OCI version)
 # ln[38] : Enroll oci8 to php.ini
 # ln[39] : Add to mods-available
 # ln[40] : Make symbolic link about oci.ini

--- a/docker_php_oci_ARM64/Readme.md
+++ b/docker_php_oci_ARM64/Readme.md
@@ -6,7 +6,7 @@ Docker : PHP - OCI 8
 - What will be installed
     - PHP 8.0
     - PHP Basic Extensions
-    - OCI8
+    - OCI8 (version 8-3.2.0)
     - Oracle Instant Client(Basic, SDK, ver. 19)
     - PHP Composer
     - PHP Laravel
@@ -24,7 +24,7 @@ Docker : PHP - OCI 8
 ***
 ## Warning
 - **This Docker Image is only available to ARM 64 CPU"**
-- **Apple Sillicon, Linux ARM Platform supported**
+- **Apple Sillicon(Verified M1, M2), Linux ARM Platform supported**
 - **This Docker Image support Oracle DB Connection**
 ***
 ## Run container


### PR DESCRIPTION
Found a problem with not building an image in an existing dockerfile

Cause: Incompatible version from 'peclinstalloci8'

Result: Modified to 'pecl installoci8-3.2.0' 

Test: Apple Macbook air [chip: M2] Normal operation completed
![스크린샷 2023-10-08 오전 1 23 00](https://github.com/2022-DB-502-Group2-Project/Develop-Test-Env/assets/112881296/081a4142-720f-4191-96e9-3affb1ec3ad8)
